### PR TITLE
Add Soldat Climb mobile game prototype (Godot 4)

### DIFF
--- a/soldat-climb-mobile/project.godot
+++ b/soldat-climb-mobile/project.godot
@@ -1,0 +1,44 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; but it can also be edited by hand if needed.
+
+[application]
+
+config/name="Soldat Climb"
+run/main_scene="res://scenes/main.tscn"
+config/features=PackedStringArray("4.2")
+
+[display]
+
+window/size/viewport_width=960
+window/size/viewport_height=540
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
+window/handheld/orientation=1
+
+[input]
+
+move_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":65,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)]
+}
+move_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)]
+}
+jump={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":87,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)]
+}
+crouch={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":83,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)]
+}
+
+[physics]
+
+common/physics_ticks_per_second=60
+
+[rendering]
+
+renderer/rendering_method="mobile"

--- a/soldat-climb-mobile/scenes/main.tscn
+++ b/soldat-climb-mobile/scenes/main.tscn
@@ -1,0 +1,61 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/main.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/player.gd" id="2"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Player" type="Node2D" parent="."]
+script = ExtResource("2")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+zoom = Vector2(2, 2)
+position_smoothing_enabled = true
+position_smoothing_speed = 8.0
+
+[node name="HUD" type="CanvasLayer" parent="."]
+layer = 5
+
+[node name="TimerLabel" type="Label" parent="HUD"]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 250.0
+offset_bottom = 40.0
+text = "00:00.000"
+label_settings = SubResource("LabelSettings_timer")
+
+[node name="DeathLabel" type="Label" parent="HUD"]
+offset_left = 10.0
+offset_top = 40.0
+offset_right = 250.0
+offset_bottom = 70.0
+text = "Deaths: 0"
+
+[node name="BestLabel" type="Label" parent="HUD"]
+offset_left = 10.0
+offset_top = 70.0
+offset_right = 250.0
+offset_bottom = 100.0
+text = "Best: --:--.---"
+
+[node name="MapNameLabel" type="Label" parent="HUD"]
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -200.0
+offset_top = 10.0
+offset_right = -10.0
+offset_bottom = 40.0
+horizontal_alignment = 2
+text = "Map Name"
+
+[node name="RestartButton" type="Button" parent="HUD"]
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -120.0
+offset_top = 45.0
+offset_right = -10.0
+offset_bottom = 75.0
+text = "Restart (R)"

--- a/soldat-climb-mobile/scripts/climb_timer.gd
+++ b/soldat-climb-mobile/scripts/climb_timer.gd
@@ -1,0 +1,69 @@
+## Climb Timer - Manages timer, checkpoints, death tracking
+extends Node
+
+signal timer_started
+signal timer_stopped(time: float)
+signal checkpoint_hit(index: int)
+signal death_counted(total: int)
+
+var running: bool = false
+var elapsed: float = 0.0
+var death_count: int = 0
+var checkpoints_hit: Array[int] = []
+var best_time: float = INF
+
+
+func _process(delta: float) -> void:
+	if running:
+		elapsed += delta
+
+
+func start_timer() -> void:
+	if not running:
+		running = true
+		elapsed = 0.0
+		death_count = 0
+		checkpoints_hit.clear()
+		timer_started.emit()
+
+
+func stop_timer() -> void:
+	if running:
+		running = false
+		if elapsed < best_time:
+			best_time = elapsed
+		timer_stopped.emit(elapsed)
+
+
+func hit_checkpoint(index: int) -> void:
+	if index not in checkpoints_hit:
+		checkpoints_hit.append(index)
+		checkpoint_hit.emit(index)
+
+
+func add_death() -> void:
+	death_count += 1
+	death_counted.emit(death_count)
+
+
+func reset() -> void:
+	running = false
+	elapsed = 0.0
+	death_count = 0
+	checkpoints_hit.clear()
+
+
+func get_time_string() -> String:
+	var minutes := int(elapsed) / 60
+	var seconds := int(elapsed) % 60
+	var millis := int((elapsed - int(elapsed)) * 1000)
+	return "%02d:%02d.%03d" % [minutes, seconds, millis]
+
+
+func get_best_time_string() -> String:
+	if best_time == INF:
+		return "--:--.---"
+	var minutes := int(best_time) / 60
+	var seconds := int(best_time) % 60
+	var millis := int((best_time - int(best_time)) * 1000)
+	return "%02d:%02d.%03d" % [minutes, seconds, millis]

--- a/soldat-climb-mobile/scripts/ghost_replay.gd
+++ b/soldat-climb-mobile/scripts/ghost_replay.gd
@@ -1,0 +1,59 @@
+## Ghost Replay - Records and plays back player position each physics frame
+extends Node2D
+
+var recording: bool = false
+var playing: bool = false
+var frames: PackedVector2Array = PackedVector2Array()
+var playback_index: int = 0
+var ghost_color := Color(0.3, 0.8, 1.0, 0.3)
+
+# Best run ghost
+var best_frames: PackedVector2Array = PackedVector2Array()
+var best_time: float = INF
+
+
+func start_recording() -> void:
+	recording = true
+	playing = false
+	frames.clear()
+	playback_index = 0
+
+
+func record_frame(pos: Vector2) -> void:
+	if recording:
+		frames.append(pos)
+
+
+func stop_recording(time: float) -> void:
+	recording = false
+	if time < best_time and frames.size() > 0:
+		best_time = time
+		best_frames = frames.duplicate()
+
+
+func start_playback() -> void:
+	if best_frames.size() == 0:
+		return
+	playing = true
+	playback_index = 0
+
+
+func stop_playback() -> void:
+	playing = false
+	playback_index = 0
+
+
+func _physics_process(_delta: float) -> void:
+	if playing and best_frames.size() > 0:
+		if playback_index < best_frames.size():
+			position = best_frames[playback_index]
+			playback_index += 1
+			queue_redraw()
+		else:
+			stop_playback()
+
+
+func _draw() -> void:
+	if playing:
+		# Draw ghost as semi-transparent rectangle
+		draw_rect(Rect2(-4, -12, 8, 18), ghost_color)

--- a/soldat-climb-mobile/scripts/main.gd
+++ b/soldat-climb-mobile/scripts/main.gd
@@ -1,0 +1,186 @@
+## Main Game Scene - Orchestrates the Climb game
+extends Node2D
+
+const MC = MovementConstants
+
+@onready var player: Node2D = $Player
+@onready var camera: Camera2D = $Camera2D
+@onready var hud: CanvasLayer = $HUD
+@onready var timer_label: Label = $HUD/TimerLabel
+@onready var death_label: Label = $HUD/DeathLabel
+@onready var best_label: Label = $HUD/BestLabel
+@onready var map_name_label: Label = $HUD/MapNameLabel
+@onready var restart_button: Button = $HUD/RestartButton
+
+var touch_controls: Node  # TouchControls instance
+var climb_timer: Node  # ClimbTimer instance
+var ghost: Node2D  # GhostReplay instance
+
+var poly_map: PolyMap
+var current_map_data: Dictionary = {}
+var checkpoint_zones: Array[Rect2] = []
+var finish_zone: Rect2 = Rect2()
+var start_triggered: bool = false
+
+# Polygon colors for rendering
+var poly_colors := {
+	MC.POLY_TYPE_NORMAL: Color(0.35, 0.30, 0.25),
+	MC.POLY_TYPE_ICE: Color(0.6, 0.85, 0.95),
+	MC.POLY_TYPE_BOUNCY: Color(0.2, 0.7, 0.3),
+	MC.POLY_TYPE_DEADLY: Color(0.8, 0.15, 0.1),
+	MC.POLY_TYPE_BLOODY_DEADLY: Color(0.7, 0.1, 0.05),
+	MC.POLY_TYPE_LAVA: Color(0.9, 0.3, 0.05),
+	MC.POLY_TYPE_HURTS: Color(0.7, 0.5, 0.2),
+}
+
+
+func _ready() -> void:
+	# Create subsystems
+	climb_timer = preload("res://scripts/climb_timer.gd").new()
+	add_child(climb_timer)
+
+	ghost = preload("res://scripts/ghost_replay.gd").new()
+	add_child(ghost)
+
+	# Connect signals
+	player.died.connect(_on_player_died)
+	restart_button.pressed.connect(_on_restart)
+
+	# Load default map
+	load_map(MapData.create_jump_course())
+
+
+func _physics_process(_delta: float) -> void:
+	# Update camera to follow player
+	camera.position = player.position
+
+	# Update HUD
+	timer_label.text = climb_timer.get_time_string()
+	death_label.text = "Deaths: %d" % climb_timer.death_count
+	best_label.text = "Best: %s" % climb_timer.get_best_time_string()
+
+	# Record ghost
+	if climb_timer.running:
+		ghost.record_frame(player.position)
+
+	# Check zones
+	_check_zones()
+
+	# Pass aim_x from screen to world space for player
+	# On desktop: mouse position
+	var mouse_screen := get_viewport().get_mouse_position()
+	var mouse_world := camera.position + (mouse_screen - get_viewport_rect().size / 2)
+	player.aim_x = mouse_world.x
+
+	queue_redraw()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	# Keyboard controls (desktop testing)
+	if event is InputEventKey or event is InputEventMouseButton:
+		player.control_left = Input.is_action_pressed("move_left")
+		player.control_right = Input.is_action_pressed("move_right")
+		player.control_up = Input.is_action_pressed("jump")
+		player.control_down = Input.is_action_pressed("crouch")
+
+
+func load_map(map_data: Dictionary) -> void:
+	current_map_data = map_data
+	poly_map = PolyMap.new()
+
+	# Load polygons
+	for p in map_data.polygons:
+		poly_map.add_polygon(p.v1, p.v2, p.v3, p.type, p.bounciness)
+	poly_map.finalize()
+
+	# Set player's map reference
+	player.map = poly_map
+
+	# Set spawn, checkpoints, finish
+	player.position = map_data.spawn
+	player.last_checkpoint = map_data.spawn
+	player.physics.pos[player.particle_idx] = map_data.spawn
+	player.physics.old_pos[player.particle_idx] = map_data.spawn
+
+	checkpoint_zones.clear()
+	for cp in map_data.get("checkpoints", []):
+		checkpoint_zones.append(cp)
+
+	finish_zone = map_data.get("finish", Rect2())
+
+	# Reset timer
+	climb_timer.reset()
+	start_triggered = false
+	ghost.stop_playback()
+	ghost.stop_recording() if ghost.recording else null
+
+	map_name_label.text = map_data.get("name", "Unknown Map")
+
+	queue_redraw()
+
+
+func _check_zones() -> void:
+	var ppos := player.position
+
+	# Start timer on first movement
+	if not start_triggered and not climb_timer.running:
+		if player.control_left or player.control_right or player.control_up:
+			start_triggered = true
+			climb_timer.start_timer()
+			ghost.start_recording()
+
+	# Checkpoints
+	for i in checkpoint_zones.size():
+		if checkpoint_zones[i].has_point(ppos):
+			player.set_checkpoint(ppos)
+			climb_timer.hit_checkpoint(i)
+
+	# Finish
+	if finish_zone.has_point(ppos) and climb_timer.running:
+		climb_timer.stop_timer()
+		ghost.stop_recording(climb_timer.elapsed)
+
+		# Start ghost playback for next attempt
+		ghost.start_playback()
+
+	# Out of bounds death
+	if ppos.y > 500 or ppos.y < -1500 or ppos.x < -600 or ppos.x > 2500:
+		player._die()
+
+
+func _on_player_died() -> void:
+	climb_timer.add_death()
+
+
+func _on_restart() -> void:
+	player._respawn()
+	climb_timer.reset()
+	start_triggered = false
+	ghost.stop_recording(INF) if ghost.recording else null
+	ghost.start_playback()
+	player.position = current_map_data.spawn
+	player.physics.pos[player.particle_idx] = current_map_data.spawn
+	player.physics.old_pos[player.particle_idx] = current_map_data.spawn
+	player.last_checkpoint = current_map_data.spawn
+
+
+func _draw() -> void:
+	# Draw all map polygons
+	if poly_map:
+		for poly in poly_map.polygons:
+			var color: Color = poly_colors.get(poly.poly_type, Color(0.4, 0.35, 0.3))
+			var points := PackedVector2Array(poly.vertices)
+			var colors := PackedColorArray([color, color, color])
+			draw_polygon(points, colors)
+
+	# Draw checkpoint zones
+	for i in checkpoint_zones.size():
+		var cp := checkpoint_zones[i]
+		var hit := i in climb_timer.checkpoints_hit
+		var color := Color(0, 1, 0, 0.3) if hit else Color(1, 1, 0, 0.2)
+		draw_rect(cp, color)
+
+	# Draw finish zone
+	if finish_zone.size != Vector2.ZERO:
+		draw_rect(finish_zone, Color(1, 0.8, 0, 0.3))
+		# Draw "FINISH" text would go here with a font

--- a/soldat-climb-mobile/scripts/map_data.gd
+++ b/soldat-climb-mobile/scripts/map_data.gd
@@ -1,0 +1,160 @@
+## Map Data - Hand-built test maps for the Climb prototype
+## Each map is an array of polygon definitions + metadata.
+## Later this will be replaced by a .pms file loader for real Soldat maps.
+
+class_name MapData
+
+const MC = MovementConstants
+
+## Map: Basic test - flat ground with a few platforms
+static func create_basic_test() -> Dictionary:
+	return {
+		"name": "Basic Test",
+		"polygons": [
+			# Ground floor
+			_poly(-500, 200, 1500, 200, 1500, 250),
+			_poly(-500, 200, 1500, 250, -500, 250),
+			# Left wall
+			_poly(-500, -400, -480, -400, -480, 200),
+			_poly(-500, -400, -480, 200, -500, 200),
+			# Platform 1
+			_poly(100, 100, 250, 100, 250, 115),
+			_poly(100, 100, 250, 115, 100, 115),
+			# Platform 2 (higher)
+			_poly(350, 0, 500, 0, 500, 15),
+			_poly(350, 0, 500, 15, 350, 15),
+			# Platform 3 (even higher)
+			_poly(600, -100, 750, -100, 750, -85),
+			_poly(600, -100, 750, -85, 600, -85),
+		],
+		"spawn": Vector2(0, 180),
+		"checkpoints": [],
+		"finish": Rect2(700, -130, 50, 30),
+	}
+
+
+## Map: Jump course - tests all jump types
+static func create_jump_course() -> Dictionary:
+	return {
+		"name": "Jump Course",
+		"polygons": [
+			# Start platform
+			_poly(-100, 200, 100, 200, 100, 250),
+			_poly(-100, 200, 100, 250, -100, 250),
+
+			# Gap jump (easy)
+			_poly(200, 200, 350, 200, 350, 250),
+			_poly(200, 200, 350, 250, 200, 250),
+
+			# Higher platform (needs side jump)
+			_poly(450, 100, 600, 100, 600, 150),
+			_poly(450, 100, 600, 150, 450, 150),
+
+			# Wall for wall-bounce (bouncy polygon)
+			_poly_typed(650, -100, 670, -100, 670, 150, MC.POLY_TYPE_BOUNCY, 1.5),
+			_poly_typed(650, -100, 670, 150, 650, 150, MC.POLY_TYPE_BOUNCY, 1.5),
+
+			# Platform after bounce
+			_poly(700, -50, 900, -50, 900, -35),
+			_poly(700, -50, 900, -35, 700, -35),
+
+			# Ice platform (slippery!)
+			_poly_typed(1000, -50, 1200, -50, 1200, -35, MC.POLY_TYPE_ICE),
+			_poly_typed(1000, -50, 1200, -35, 1000, -35, MC.POLY_TYPE_ICE),
+
+			# Backflip challenge - small platform, need precise backflip
+			_poly(1300, -150, 1380, -150, 1380, -135),
+			_poly(1300, -150, 1380, -135, 1300, -135),
+
+			# Final platform
+			_poly(1450, -250, 1600, -250, 1600, -235),
+			_poly(1450, -250, 1600, -235, 1450, -235),
+
+			# Death pit floor
+			_poly_typed(-200, 400, 1800, 400, 1800, 450, MC.POLY_TYPE_DEADLY),
+			_poly_typed(-200, 400, 1800, 450, -200, 450, MC.POLY_TYPE_DEADLY),
+		],
+		"spawn": Vector2(0, 180),
+		"checkpoints": [
+			Rect2(500, 60, 50, 40),
+			Rect2(800, -90, 50, 40),
+			Rect2(1350, -190, 30, 40),
+		],
+		"finish": Rect2(1500, -290, 50, 40),
+	}
+
+
+## Map: Climb tower - vertical climb challenge
+static func create_climb_tower() -> Dictionary:
+	var polys := []
+
+	# Base floor
+	polys.append_array([
+		_poly(-200, 300, 400, 300, 400, 350),
+		_poly(-200, 300, 400, 350, -200, 350),
+	])
+
+	# Zigzag platforms going up (need alternating direction jumps)
+	var heights := [200, 100, 0, -100, -200, -300, -400, -500, -600, -700]
+	for i in heights.size():
+		var x_offset: float = 0 if i % 2 == 0 else 200
+		var y: float = heights[i]
+		polys.append(_poly(x_offset, y, x_offset + 150, y, x_offset + 150, y + 15))
+		polys.append(_poly(x_offset, y, x_offset + 150, y + 15, x_offset, y + 15))
+
+	# Left and right walls
+	polys.append_array([
+		_poly(-220, -800, -200, -800, -200, 300),
+		_poly(-220, -800, -200, 300, -220, 300),
+		_poly(400, -800, 420, -800, 420, 300),
+		_poly(400, -800, 420, 300, 400, 300),
+	])
+
+	# Lava at bottom
+	polys.append_array([
+		_poly_typed(-220, 350, 420, 350, 420, 400, MC.POLY_TYPE_LAVA),
+		_poly_typed(-220, 350, 420, 400, -220, 400, MC.POLY_TYPE_LAVA),
+	])
+
+	# Bouncy ceiling at top (fun surprise)
+	polys.append_array([
+		_poly_typed(-220, -820, 420, -820, 420, -800, MC.POLY_TYPE_BOUNCY, 2.0),
+		_poly_typed(-220, -820, 420, -800, -220, -800, MC.POLY_TYPE_BOUNCY, 2.0),
+	])
+
+	var checkpoints: Array[Rect2] = []
+	for i in range(2, heights.size(), 3):
+		var x_offset: float = 0 if i % 2 == 0 else 200
+		checkpoints.append(Rect2(x_offset + 50, heights[i] - 40, 50, 40))
+
+	return {
+		"name": "Climb Tower",
+		"polygons": polys,
+		"spawn": Vector2(50, 280),
+		"checkpoints": checkpoints,
+		"finish": Rect2(250, -740, 50, 40),
+	}
+
+
+## Helper: create a normal polygon definition
+static func _poly(x1: float, y1: float, x2: float, y2: float,
+		x3: float, y3: float) -> Dictionary:
+	return {
+		"v1": Vector2(x1, y1),
+		"v2": Vector2(x2, y2),
+		"v3": Vector2(x3, y3),
+		"type": MC.POLY_TYPE_NORMAL,
+		"bounciness": 0.0,
+	}
+
+
+## Helper: create a typed polygon
+static func _poly_typed(x1: float, y1: float, x2: float, y2: float,
+		x3: float, y3: float, type: int, bounce: float = 0.0) -> Dictionary:
+	return {
+		"v1": Vector2(x1, y1),
+		"v2": Vector2(x2, y2),
+		"v3": Vector2(x3, y3),
+		"type": type,
+		"bounciness": bounce,
+	}

--- a/soldat-climb-mobile/scripts/movement_constants.gd
+++ b/soldat-climb-mobile/scripts/movement_constants.gd
@@ -1,0 +1,69 @@
+## Movement Constants - Direct port from Soldat's Constants.pas and Sprites.pas
+## These values define the exact "feel" of Soldat movement.
+## DO NOT CHANGE unless intentionally altering the game feel.
+
+class_name MovementConstants
+
+# From Constants.pas lines 39-49
+const RUNSPEED: float = 0.118
+const RUNSPEEDUP: float = RUNSPEED / 6.0  # slight upward force while running
+const FLYSPEED: float = 0.03  # air control (much weaker than ground)
+const JUMPSPEED: float = 0.66  # vertical jump impulse
+const CROUCHRUNSPEED: float = RUNSPEED / 0.6
+const PRONESPEED: float = RUNSPEED * 4.0
+const ROLLSPEED: float = RUNSPEED / 1.2
+const JUMPDIRSPEED: float = 0.30  # side jump impulse
+
+# From Cvar.pas lines 225-234
+const GRAV: float = 0.06
+const PLAYER_GRAVITY: float = 1.06 * GRAV  # gostek skeleton gravity
+const BULLET_GRAVITY: float = GRAV * 2.25
+const SPARK_GRAVITY: float = GRAV / 1.4
+
+# From Sprites.pas lines 24-31 - surface friction coefficients
+const SURFACECOEFX: float = 0.970
+const SURFACECOEFY: float = 0.970
+const CROUCHMOVESURFACECOEFX: float = 0.850
+const CROUCHMOVESURFACECOEFY: float = 0.970
+const STANDSURFACECOEFX: float = 0.000  # instant stop when standing
+const STANDSURFACECOEFY: float = 0.000
+const GRENADE_SURFACECOEF: float = 0.880
+const SPARK_SURFACECOEF: float = 0.700
+
+# From Sprites.pas lines 50-51
+const SLIDELIMIT: float = 0.2
+const MAX_VELOCITY: float = 11.0
+
+# Physics timestep
+const PHYSICS_TIMESTEP: float = 1.0  # Verlet timestep
+const TICKS_PER_SECOND: int = 60
+
+# Verlet damping (from Parts.pas)
+const V_DAMPING: float = 0.99
+
+# Animation frame windows for physics impulses
+# These are CRITICAL - they define when forces are applied during animations
+const JUMP_FORCE_START_FRAME: int = 9
+const JUMP_FORCE_END_FRAME: int = 14  # exclusive (< 15 in original)
+const SIDEJUMP_FORCE_START_FRAME: int = 4
+const SIDEJUMP_FORCE_END_FRAME: int = 10  # exclusive (< 11 in original)
+const BACKFLIP_BOOST_START_FRAME: int = 2
+const BACKFLIP_BOOST_END_FRAME: int = 7  # exclusive (< 8 in original)
+
+# Backflip jump boost multiplier (from Control.pas line 1614)
+const BACKFLIP_JUMP_BOOST: float = JUMPDIRSPEED * 1.5
+const BACKFLIP_X_DAMPEN: float = 0.5
+const BACKFLIP_VEL_X_DAMPEN: float = 0.8
+
+# Polygon types (from PolyMap.pas lines 22-47)
+const POLY_TYPE_NORMAL: int = 0
+const POLY_TYPE_ONLY_BULLETS: int = 1
+const POLY_TYPE_ONLY_PLAYER: int = 2
+const POLY_TYPE_DOESNT_COLLIDE: int = 3
+const POLY_TYPE_ICE: int = 4
+const POLY_TYPE_DEADLY: int = 5
+const POLY_TYPE_BLOODY_DEADLY: int = 6
+const POLY_TYPE_HURTS: int = 7
+const POLY_TYPE_REGENERATES: int = 8
+const POLY_TYPE_LAVA: int = 9
+const POLY_TYPE_BOUNCY: int = 18

--- a/soldat-climb-mobile/scripts/player.gd
+++ b/soldat-climb-mobile/scripts/player.gd
@@ -1,0 +1,486 @@
+## Player - Port of Soldat's Control.pas movement state machine + Sprites.pas ground detection
+## This is the core of the Soldat movement feel.
+extends Node2D
+
+const MC = MovementConstants
+
+# Animation state IDs (simplified from Soldat's full animation system)
+enum Anim {
+	STAND, RUN, RUN_BACK, JUMP, JUMP_SIDE, FALL,
+	CROUCH, CROUCH_RUN, CROUCH_RUN_BACK,
+	ROLL, ROLL_BACK,  # Roll = forward roll, RollBack = backflip
+	GET_UP,
+}
+
+# Animation frame counts (from Soldat's animation data)
+const ANIM_FRAMES := {
+	Anim.STAND: 1,
+	Anim.RUN: 32,
+	Anim.RUN_BACK: 32,
+	Anim.JUMP: 14,
+	Anim.JUMP_SIDE: 11,
+	Anim.FALL: 1,
+	Anim.CROUCH: 15,
+	Anim.CROUCH_RUN: 15,
+	Anim.CROUCH_RUN_BACK: 15,
+	Anim.ROLL: 14,
+	Anim.ROLL_BACK: 14,
+	Anim.GET_UP: 24,
+}
+
+# Verlet physics for the player particle
+var physics: VerletPhysics
+var particle_idx: int = 0  # index in physics system
+
+# State
+var direction: int = 1  # 1 = facing right, -1 = facing left
+var on_ground: bool = false
+var on_ground_last_frame: bool = false
+var on_ground_permanent: bool = false
+
+# Animation state
+var legs_anim: Anim = Anim.STAND
+var legs_frame: int = 1
+var legs_num_frames: int = 1
+var body_anim: Anim = Anim.STAND
+
+# Input state
+var control_left: bool = false
+var control_right: bool = false
+var control_up: bool = false
+var control_down: bool = false
+var aim_x: float = 0.0  # world-space aim X position (from mouse or touch)
+
+# Map reference
+var map: PolyMap
+
+# Climb mode
+var is_dead: bool = false
+var death_count: int = 0
+var last_checkpoint: Vector2 = Vector2.ZERO
+
+signal died
+signal checkpoint_reached(pos: Vector2)
+signal finished(time: float)
+
+
+func _ready() -> void:
+	physics = VerletPhysics.new()
+	physics.gravity = MC.PLAYER_GRAVITY
+	physics.v_damping = MC.V_DAMPING
+	physics.time_step = MC.PHYSICS_TIMESTEP
+	physics.create_part(position, Vector2.ZERO, 1.0, particle_idx)
+	last_checkpoint = position
+
+
+func _physics_process(_delta: float) -> void:
+	if is_dead:
+		return
+
+	# Update direction from aim (port of Sprites.pas line 553-556)
+	if aim_x >= physics.pos[particle_idx].x:
+		direction = 1
+	else:
+		direction = -1
+
+	# Run the movement state machine (port of Control.pas)
+	_process_movement()
+
+	# Verlet physics step
+	physics.do_verlet_timestep()
+
+	# Clamp velocity (port of Sprites.pas MAX_VELOCITY)
+	var vel := physics.velocity[particle_idx]
+	if vel.length() > MC.MAX_VELOCITY:
+		vel = vel.normalized() * MC.MAX_VELOCITY
+		physics.pos[particle_idx] = physics.old_pos[particle_idx] + vel
+
+	# Ground detection (port of Sprites.pas lines 856-876)
+	_check_ground()
+
+	# Update position for rendering
+	position = physics.pos[particle_idx]
+
+	# Update animation frame
+	_advance_animation()
+
+	queue_redraw()
+
+
+func _draw() -> void:
+	# Simple gostek representation - colored rectangle + direction indicator
+	var color := Color.CORNFLOWER_BLUE
+	if legs_anim == Anim.CROUCH or legs_anim == Anim.CROUCH_RUN or legs_anim == Anim.CROUCH_RUN_BACK:
+		draw_rect(Rect2(-5, -6, 10, 12), color)
+	elif legs_anim == Anim.ROLL or legs_anim == Anim.ROLL_BACK:
+		draw_circle(Vector2.ZERO, 6, color)
+	else:
+		draw_rect(Rect2(-4, -12, 8, 18), color)
+
+	# Direction indicator (eyes)
+	var eye_x := 2.0 * direction
+	draw_circle(Vector2(eye_x, -8), 1.5, Color.WHITE)
+
+	# Ground indicator
+	if on_ground:
+		draw_circle(Vector2(0, 8), 1, Color.GREEN)
+
+
+## Port of Control.pas lines 1590-1984 — the full movement state machine
+func _process_movement() -> void:
+	var num := particle_idx
+
+	# Active roll/backflip handling (highest priority, from lines 1590-1620)
+	if body_anim == Anim.ROLL or body_anim == Anim.ROLL_BACK:
+		if legs_anim == Anim.ROLL:
+			if on_ground:
+				physics.forces[num].x = direction * MC.ROLLSPEED
+			else:
+				physics.forces[num].x = direction * 2 * MC.FLYSPEED
+		elif legs_anim == Anim.ROLL_BACK:
+			if on_ground:
+				physics.forces[num].x = -direction * MC.ROLLSPEED
+			else:
+				physics.forces[num].x = -direction * 2 * MC.FLYSPEED
+
+			# Backflip jump boost (lines 1608-1618) — THE core Climb trick
+			if legs_frame > MC.BACKFLIP_BOOST_START_FRAME and \
+					legs_frame < MC.BACKFLIP_BOOST_END_FRAME:
+				if control_up:
+					physics.forces[num].y -= MC.BACKFLIP_JUMP_BOOST
+					physics.forces[num].x *= MC.BACKFLIP_X_DAMPEN
+					physics.velocity[num].x *= MC.BACKFLIP_VEL_X_DAMPEN
+
+		# Handle roll/backflip completion (lines 2028-2075)
+		if legs_frame >= _get_num_frames(legs_anim):
+			if on_ground:
+				if control_down:
+					if control_left or control_right:
+						if body_anim == Anim.ROLL:
+							_set_legs_anim(Anim.CROUCH_RUN)
+						else:
+							_set_legs_anim(Anim.CROUCH_RUN_BACK)
+					else:
+						_set_legs_anim(Anim.CROUCH)
+			elif body_anim == Anim.ROLL_BACK and control_up:
+				if control_left or control_right:
+					if (direction == 1) != control_left:
+						_set_legs_anim(Anim.RUN)
+					else:
+						_set_legs_anim(Anim.RUN_BACK)
+				else:
+					_set_legs_anim(Anim.FALL)
+			elif control_down:
+				if control_left or control_right:
+					if body_anim == Anim.ROLL:
+						_set_legs_anim(Anim.CROUCH_RUN)
+					else:
+						_set_legs_anim(Anim.CROUCH_RUN_BACK)
+				else:
+					_set_legs_anim(Anim.CROUCH)
+			body_anim = Anim.STAND
+		return  # Roll/backflip takes priority over other movement
+
+	# Down+Right: roll or crouch-run (lines 1622-1676)
+	if control_right and control_down:
+		if on_ground:
+			if legs_anim in [Anim.RUN, Anim.RUN_BACK, Anim.FALL]:
+				# Direction determines Roll vs RollBack
+				if direction == 1:
+					_set_anim(Anim.ROLL)
+				else:
+					_set_anim(Anim.ROLL_BACK)
+			else:
+				if direction == 1:
+					_set_legs_anim(Anim.CROUCH_RUN)
+				else:
+					_set_legs_anim(Anim.CROUCH_RUN_BACK)
+
+			if legs_anim == Anim.CROUCH_RUN or legs_anim == Anim.CROUCH_RUN_BACK:
+				physics.forces[num].x = MC.CROUCHRUNSPEED
+			elif legs_anim == Anim.ROLL or legs_anim == Anim.ROLL_BACK:
+				physics.forces[num].x = 2 * MC.CROUCHRUNSPEED
+
+	# Down+Left: roll or crouch-run (lines 1678-1730)
+	elif control_left and control_down:
+		if on_ground:
+			if legs_anim in [Anim.RUN, Anim.RUN_BACK, Anim.FALL]:
+				if direction == 1:
+					_set_anim(Anim.ROLL_BACK)
+				else:
+					_set_anim(Anim.ROLL)
+			else:
+				if direction == 1:
+					_set_legs_anim(Anim.CROUCH_RUN_BACK)
+				else:
+					_set_legs_anim(Anim.CROUCH_RUN)
+
+			if legs_anim == Anim.CROUCH_RUN or legs_anim == Anim.CROUCH_RUN_BACK:
+				physics.forces[num].x = -MC.CROUCHRUNSPEED
+			elif legs_anim == Anim.ROLL or legs_anim == Anim.ROLL_BACK:
+				physics.forces[num].x = -2 * MC.CROUCHRUNSPEED
+
+	# Right+Up: side jump right (lines 1777-1822)
+	elif control_right and control_up:
+		if on_ground:
+			if legs_anim in [Anim.RUN, Anim.RUN_BACK, Anim.STAND,
+					Anim.CROUCH, Anim.CROUCH_RUN, Anim.CROUCH_RUN_BACK]:
+				_set_legs_anim(Anim.JUMP_SIDE)
+			if legs_frame >= _get_num_frames(legs_anim):
+				_set_legs_anim(Anim.RUN)
+		elif legs_anim in [Anim.ROLL, Anim.ROLL_BACK]:
+			if direction == 1:
+				_set_legs_anim(Anim.RUN)
+			else:
+				_set_legs_anim(Anim.RUN_BACK)
+
+		# Jump→JumpSide conversion mid-air (line 1807-1812)
+		if legs_anim == Anim.JUMP:
+			if legs_frame < 10:
+				_set_legs_anim(Anim.JUMP_SIDE)
+
+		# Side jump forces (lines 1815-1822)
+		if legs_anim == Anim.JUMP_SIDE:
+			if legs_frame > MC.SIDEJUMP_FORCE_START_FRAME and \
+					legs_frame < MC.SIDEJUMP_FORCE_END_FRAME:
+				physics.forces[num].x = MC.JUMPDIRSPEED
+				physics.forces[num].y = -MC.JUMPDIRSPEED / 1.2
+
+	# Left+Up: side jump left (lines 1825-1870)
+	elif control_left and control_up:
+		if on_ground:
+			if legs_anim in [Anim.RUN, Anim.RUN_BACK, Anim.STAND,
+					Anim.CROUCH, Anim.CROUCH_RUN, Anim.CROUCH_RUN_BACK]:
+				_set_legs_anim(Anim.JUMP_SIDE)
+			if legs_frame >= _get_num_frames(legs_anim):
+				_set_legs_anim(Anim.RUN)
+		elif legs_anim in [Anim.ROLL, Anim.ROLL_BACK]:
+			if direction == -1:
+				_set_legs_anim(Anim.RUN)
+			else:
+				_set_legs_anim(Anim.RUN_BACK)
+
+		if legs_anim == Anim.JUMP:
+			if legs_frame < 10:
+				_set_legs_anim(Anim.JUMP_SIDE)
+
+		if legs_anim == Anim.JUMP_SIDE:
+			if legs_frame > MC.SIDEJUMP_FORCE_START_FRAME and \
+					legs_frame < MC.SIDEJUMP_FORCE_END_FRAME:
+				physics.forces[num].x = -MC.JUMPDIRSPEED
+				physics.forces[num].y = -MC.JUMPDIRSPEED / 1.2
+
+	# Up only: vertical jump (lines 1873-1898)
+	elif control_up:
+		if on_ground:
+			if legs_anim != Anim.JUMP:
+				_set_legs_anim(Anim.JUMP)
+			if legs_frame >= _get_num_frames(legs_anim):
+				_set_legs_anim(Anim.STAND)
+
+		if legs_anim == Anim.JUMP:
+			if legs_frame > MC.JUMP_FORCE_START_FRAME and \
+					legs_frame < MC.JUMP_FORCE_END_FRAME:
+				physics.forces[num].y = -MC.JUMPSPEED
+			if legs_frame >= _get_num_frames(legs_anim):
+				_set_legs_anim(Anim.FALL)
+
+	# Down only: crouch (lines 1901-1913)
+	elif control_down:
+		if on_ground:
+			_set_legs_anim(Anim.CROUCH)
+
+	# Right only: run (lines 1916-1940)
+	elif control_right:
+		if direction == 1:
+			_set_legs_anim(Anim.RUN)
+		else:
+			_set_legs_anim(Anim.RUN_BACK)
+
+		if on_ground:
+			physics.forces[num].x = MC.RUNSPEED
+			physics.forces[num].y = -MC.RUNSPEEDUP
+		else:
+			physics.forces[num].x = MC.FLYSPEED
+
+	# Left only: run (lines 1943-1967)
+	elif control_left:
+		if direction == -1:
+			_set_legs_anim(Anim.RUN)
+		else:
+			_set_legs_anim(Anim.RUN_BACK)
+
+		if on_ground:
+			physics.forces[num].x = -MC.RUNSPEED
+			physics.forces[num].y = -MC.RUNSPEEDUP
+		else:
+			physics.forces[num].x = -MC.FLYSPEED
+
+	# No input (lines 1970-1983)
+	else:
+		if on_ground:
+			_set_legs_anim(Anim.STAND)
+		else:
+			_set_legs_anim(Anim.FALL)
+
+
+## Port of Sprites.pas lines 856-876 — Ground detection
+func _check_ground() -> void:
+	if not map:
+		return
+
+	var pos := physics.pos[particle_idx]
+	var vel := physics.velocity[particle_idx]
+	on_ground = false
+
+	# Leg collision check at (x+2, y+2) and (x-2, y+2)
+	# Port of Sprites.pas lines 858-862
+	var check_pos := pos + vel
+	var result := _check_map_collision(check_pos.x + 2, check_pos.y + 2)
+	if not result.collided:
+		result = _check_map_collision(check_pos.x - 2, check_pos.y + 2)
+
+	if result.collided:
+		on_ground = true
+
+	# Vertex collision check within radius 3 (line 868-870)
+	if not on_ground:
+		var r := map.collision_test(check_pos)
+		if r.collided and r.distance < 3.0:
+			on_ground = true
+
+	# OnGroundPermanent: stable over 2 frames (line 873-874)
+	if not (on_ground != on_ground_last_frame):
+		on_ground_permanent = on_ground
+	on_ground_last_frame = on_ground
+
+
+## Port of Sprites.pas CheckMapCollision (line 2573)
+## Handles collision response, surface friction, bouncy/ice/deadly polygons
+func _check_map_collision(x: float, y: float) -> Dictionary:
+	if not map:
+		return {"collided": false}
+
+	var num := particle_idx
+	var pos := Vector2(x, y)
+	var vel := physics.velocity[num]
+	var test_pos := pos + vel
+
+	var result := map.collision_test(test_pos)
+	if not result.collided:
+		return {"collided": false}
+
+	var poly_type: int = result.poly_type
+	var perp_vec: Vector2 = result.perp_vec
+	var step_normal: Vector2 = result.normal
+
+	# Handle special polygon types
+	if poly_type == MC.POLY_TYPE_DEADLY or poly_type == MC.POLY_TYPE_BLOODY_DEADLY:
+		_die()
+		return result
+	if poly_type == MC.POLY_TYPE_LAVA:
+		_die()
+		return result
+
+	# Fall sound thresholds (lines 2625-2646) — just for feel tracking
+	# TODO: Add sound effects
+
+	# Collision response (lines 2718-2750)
+	var perp := result.normal
+	var d := result.distance
+	perp = perp.normalized() * d
+
+	var vel_len := vel.length()
+	if perp.length() > vel_len:
+		perp = perp.normalized() * vel_len
+
+	physics.old_pos[num] = physics.pos[num]
+	physics.pos[num] -= perp
+
+	if poly_type == MC.POLY_TYPE_BOUNCY:
+		perp = perp.normalized() * result.bounciness * vel_len
+
+	physics.velocity[num] -= perp
+	# Update velocity from position change
+	physics.velocity[num] = physics.pos[num] - physics.old_pos[num]
+
+	# Surface friction (lines 2753-2822)
+	# Only apply when the step normal points upward (standing surface)
+	if step_normal.y > MC.SLIDELIMIT:
+		if poly_type != MC.POLY_TYPE_ICE and poly_type != MC.POLY_TYPE_BOUNCY:
+			if legs_anim in [Anim.STAND, Anim.FALL, Anim.CROUCH]:
+				# Standing friction: instant stop
+				physics.velocity[num].x *= MC.STANDSURFACECOEFX
+				physics.velocity[num].y *= MC.STANDSURFACECOEFY
+				physics.forces[num].x -= physics.velocity[num].x
+			else:
+				# Moving friction
+				physics.velocity[num].x *= MC.SURFACECOEFX
+				physics.velocity[num].y *= MC.SURFACECOEFY
+
+		# Cancel gravity when standing still on flat ground (lines 2768-2771)
+		if legs_anim in [Anim.STAND, Anim.CROUCH, Anim.FALL]:
+			if abs(physics.velocity[num].x) < MC.SLIDELIMIT and \
+					step_normal.y > MC.SLIDELIMIT:
+				physics.pos[num] = physics.old_pos[num]
+				physics.forces[num].y -= MC.PLAYER_GRAVITY
+
+	return result
+
+
+func _die() -> void:
+	if is_dead:
+		return
+	is_dead = true
+	death_count += 1
+	died.emit()
+
+	# Respawn at last checkpoint after a short delay
+	get_tree().create_timer(0.5).timeout.connect(_respawn)
+
+
+func _respawn() -> void:
+	physics.pos[particle_idx] = last_checkpoint
+	physics.old_pos[particle_idx] = last_checkpoint
+	physics.velocity[particle_idx] = Vector2.ZERO
+	physics.forces[particle_idx] = Vector2.ZERO
+	position = last_checkpoint
+	is_dead = false
+	legs_anim = Anim.STAND
+	legs_frame = 1
+	body_anim = Anim.STAND
+
+
+func set_checkpoint(pos: Vector2) -> void:
+	last_checkpoint = pos
+	checkpoint_reached.emit(pos)
+
+
+func _set_legs_anim(anim: Anim) -> void:
+	if legs_anim != anim:
+		legs_anim = anim
+		legs_frame = 1
+		legs_num_frames = _get_num_frames(anim)
+
+
+func _set_anim(anim: Anim) -> void:
+	_set_legs_anim(anim)
+	body_anim = anim
+	legs_frame = 1
+
+
+func _get_num_frames(anim: Anim) -> int:
+	return ANIM_FRAMES.get(anim, 1)
+
+
+func _advance_animation() -> void:
+	legs_frame += 1
+	if legs_frame > legs_num_frames:
+		# Some animations loop, others transition
+		match legs_anim:
+			Anim.RUN, Anim.RUN_BACK, Anim.CROUCH_RUN, Anim.CROUCH_RUN_BACK:
+				legs_frame = 1  # loop
+			Anim.STAND, Anim.FALL, Anim.CROUCH:
+				legs_frame = legs_num_frames  # hold last frame
+			_:
+				pass  # Let state machine handle transitions

--- a/soldat-climb-mobile/scripts/poly_map.gd
+++ b/soldat-climb-mobile/scripts/poly_map.gd
@@ -1,0 +1,184 @@
+## Polygon Map - Direct port from Soldat's PolyMap.pas
+## Handles polygon collision detection with sector-based spatial partitioning.
+
+class_name PolyMap
+extends RefCounted
+
+const MC = MovementConstants
+
+# Map polygon structure
+class MapPolygon:
+	var vertices: Array[Vector2] = []  # 3 vertices
+	var normals: Array[Vector2] = []  # 3 edge normals (perpendiculars)
+	var poly_type: int = 0
+	var bounciness: float = 0.0
+
+	func _init(v1: Vector2 = Vector2.ZERO, v2: Vector2 = Vector2.ZERO,
+			v3: Vector2 = Vector2.ZERO, type: int = 0, bounce: float = 0.0):
+		vertices = [v1, v2, v3]
+		poly_type = type
+		bounciness = bounce
+		_compute_normals()
+
+	func _compute_normals() -> void:
+		# Compute edge perpendicular normals (inward-pointing)
+		normals.clear()
+		for i in 3:
+			var j := (i + 1) % 3
+			var edge := vertices[j] - vertices[i]
+			# Perpendicular (rotated 90 degrees) - inward pointing
+			var perp := Vector2(-edge.y, edge.x).normalized()
+			normals.append(perp)
+
+
+# Map data
+var polygons: Array[MapPolygon] = []
+var sectors_division: float = 100.0
+var sectors_num: int = 25
+var sectors: Dictionary = {}  # Key: Vector2i(sx, sy), Value: Array[int] (polygon indices)
+
+# Spawnpoints and zones
+var spawn_point: Vector2 = Vector2.ZERO
+var checkpoints: Array[Rect2] = []
+var finish_zone: Rect2 = Rect2()
+
+
+## Port of PolyMap.pas PointInPoly (line 410)
+## Uses cross-product winding test
+func point_in_poly(p: Vector2, poly: MapPolygon) -> bool:
+	var a := poly.vertices[0]
+	var b := poly.vertices[1]
+	var c := poly.vertices[2]
+
+	var ap_x := p.x - a.x
+	var ap_y := p.y - a.y
+
+	var p_ab := (b.x - a.x) * ap_y - (b.y - a.y) * ap_x > 0
+	var p_ac := (c.x - a.x) * ap_y - (c.y - a.y) * ap_x > 0
+
+	if p_ac == p_ab:
+		return false
+
+	if ((c.x - b.x) * (p.y - b.y) - (c.y - b.y) * (p.x - b.x) > 0) != p_ab:
+		return false
+
+	return true
+
+
+## Port of PolyMap.pas PointInPolyEdges (line 382)
+## Half-plane test using precomputed perpendiculars
+func point_in_poly_edges(p: Vector2, poly_idx: int) -> bool:
+	var poly := polygons[poly_idx]
+	for i in 3:
+		var u := p - poly.vertices[i]
+		var d := poly.normals[i].dot(u)
+		if d < 0:
+			return false
+	return true
+
+
+## Port of PolyMap.pas ClosestPerpendicular (line 457)
+## Returns the perpendicular normal of the closest edge and the distance
+func closest_perpendicular(poly_idx: int, pos: Vector2) -> Dictionary:
+	var poly := polygons[poly_idx]
+	var min_dist := INF
+	var best_edge := 0
+
+	for i in 3:
+		var j := (i + 1) % 3
+		var d := _point_line_distance(poly.vertices[i], poly.vertices[j], pos)
+		if d < min_dist:
+			min_dist = d
+			best_edge = i
+
+	return {
+		"normal": poly.normals[best_edge],
+		"distance": min_dist,
+		"edge": best_edge,
+	}
+
+
+## Port of PolyMap.pas CollisionTest (line 536)
+## Sector-based collision test with perpendicular response vector
+func collision_test(pos: Vector2) -> Dictionary:
+	var sx := roundi(pos.x / sectors_division)
+	var sy := roundi(pos.y / sectors_division)
+
+	var key := Vector2i(sx, sy)
+	if not sectors.has(key):
+		return {"collided": false}
+
+	var sector_polys: Array = sectors[key]
+	for poly_idx in sector_polys:
+		var poly := polygons[poly_idx]
+
+		# Skip non-colliding types
+		if poly.poly_type == MC.POLY_TYPE_DOESNT_COLLIDE:
+			continue
+		if poly.poly_type == MC.POLY_TYPE_ONLY_BULLETS:
+			continue
+
+		if point_in_poly(pos, poly):
+			var perp_data := closest_perpendicular(poly_idx, pos)
+			var perp_vec: Vector2 = perp_data.normal * 1.5 * perp_data.distance
+
+			return {
+				"collided": true,
+				"perp_vec": perp_vec,
+				"poly_type": poly.poly_type,
+				"poly_idx": poly_idx,
+				"bounciness": poly.bounciness,
+				"normal": perp_data.normal,
+				"distance": perp_data.distance,
+			}
+
+	return {"collided": false}
+
+
+## Build sector spatial partitioning from polygons
+func build_sectors() -> void:
+	sectors.clear()
+	for i in polygons.size():
+		var poly := polygons[i]
+		# Find bounding box of polygon
+		var min_v := poly.vertices[0]
+		var max_v := poly.vertices[0]
+		for v in poly.vertices:
+			min_v.x = min(min_v.x, v.x)
+			min_v.y = min(min_v.y, v.y)
+			max_v.x = max(max_v.x, v.x)
+			max_v.y = max(max_v.y, v.y)
+
+		# Add polygon to all sectors it overlaps
+		var sx_min := floori(min_v.x / sectors_division) - 1
+		var sx_max := ceili(max_v.x / sectors_division) + 1
+		var sy_min := floori(min_v.y / sectors_division) - 1
+		var sy_max := ceili(max_v.y / sectors_division) + 1
+
+		for sx in range(sx_min, sx_max + 1):
+			for sy in range(sy_min, sy_max + 1):
+				var key := Vector2i(sx, sy)
+				if not sectors.has(key):
+					sectors[key] = []
+				sectors[key].append(i)
+
+
+## Helper: point-to-line-segment distance
+func _point_line_distance(a: Vector2, b: Vector2, p: Vector2) -> float:
+	var ab := b - a
+	var ap := p - a
+	var t := clampf(ab.dot(ap) / ab.length_squared(), 0.0, 1.0)
+	var closest := a + ab * t
+	return p.distance_to(closest)
+
+
+## Add a polygon to the map
+func add_polygon(v1: Vector2, v2: Vector2, v3: Vector2,
+		type: int = 0, bounce: float = 0.0) -> void:
+	var poly := MapPolygon.new(v1, v2, v3, type, bounce)
+	polygons.append(poly)
+
+
+## Rebuild after adding polygons
+func finalize() -> void:
+	build_sectors()

--- a/soldat-climb-mobile/scripts/touch_controls.gd
+++ b/soldat-climb-mobile/scripts/touch_controls.gd
@@ -1,0 +1,164 @@
+## Touch Controls with Input Buffering
+## Handles mobile touch input and keyboard fallback.
+## Right zone: aim zone (touch position = facing direction) + tap=jump, swipe down=crouch
+## Left zone: d-pad for left/right movement
+extends CanvasLayer
+
+signal input_changed(left: bool, right: bool, up: bool, down: bool, aim_x: float)
+
+# Touch zones (fractions of screen width)
+const LEFT_ZONE_WIDTH := 0.4  # Left 40% for d-pad
+const DPAD_BUTTON_SIZE := 80.0
+const ACTION_BUTTON_SIZE := 80.0
+const BUTTON_MARGIN := 20.0
+
+# Input buffering (5 frames at 60fps = ~83ms)
+const BUFFER_FRAMES := 5
+
+# State
+var control_left := false
+var control_right := false
+var control_up := false
+var control_down := false
+var aim_x := 0.0  # World-space X for facing direction
+
+# Touch tracking
+var _left_touch_id := -1
+var _right_touch_id := -1
+var _right_touch_start := Vector2.ZERO
+var _right_touch_current := Vector2.ZERO
+
+# Input buffer for jump (allows slightly early presses to register)
+var _jump_buffer: int = 0
+var _crouch_buffer: int = 0
+
+# Reference to player for aim-relative-to-player calculation
+var player_screen_x: float = 480.0  # Updated each frame by main scene
+
+
+func _ready() -> void:
+	layer = 10  # Render above game
+
+
+func _process(_delta: float) -> void:
+	# Keyboard fallback (for desktop testing)
+	if not _has_active_touches():
+		control_left = Input.is_action_pressed("move_left")
+		control_right = Input.is_action_pressed("move_right")
+		control_up = Input.is_action_pressed("jump")
+		control_down = Input.is_action_pressed("crouch")
+
+		# Mouse for aim direction (desktop)
+		aim_x = get_viewport().get_mouse_position().x
+
+	# Tick down input buffers
+	if _jump_buffer > 0:
+		_jump_buffer -= 1
+		control_up = true
+
+	if _crouch_buffer > 0:
+		_crouch_buffer -= 1
+		control_down = true
+
+	input_changed.emit(control_left, control_right, control_up, control_down, aim_x)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		_handle_screen_touch(event as InputEventScreenTouch)
+	elif event is InputEventScreenDrag:
+		_handle_screen_drag(event as InputEventScreenDrag)
+
+
+func _handle_screen_touch(event: InputEventScreenTouch) -> void:
+	var screen_width := get_viewport().get_visible_rect().size.x
+	var screen_height := get_viewport().get_visible_rect().size.y
+	var zone_boundary := screen_width * LEFT_ZONE_WIDTH
+
+	if event.pressed:
+		if event.position.x < zone_boundary:
+			# Left zone: d-pad
+			_left_touch_id = event.index
+			_update_dpad(event.position, screen_height)
+		else:
+			# Right zone: aim + actions
+			_right_touch_id = event.index
+			_right_touch_start = event.position
+			_right_touch_current = event.position
+
+			# Aim direction from touch position relative to player
+			aim_x = event.position.x  # Will be converted to world space by main scene
+
+			# Tap = jump (buffer it)
+			_jump_buffer = BUFFER_FRAMES
+	else:
+		if event.index == _left_touch_id:
+			_left_touch_id = -1
+			control_left = false
+			control_right = false
+		elif event.index == _right_touch_id:
+			_right_touch_id = -1
+			# Check for swipe down on release
+			var swipe := _right_touch_current - _right_touch_start
+			if swipe.y > 40 and abs(swipe.x) < abs(swipe.y):
+				_crouch_buffer = BUFFER_FRAMES
+
+
+func _handle_screen_drag(event: InputEventScreenDrag) -> void:
+	var screen_height := get_viewport().get_visible_rect().size.y
+
+	if event.index == _left_touch_id:
+		_update_dpad(event.position, screen_height)
+	elif event.index == _right_touch_id:
+		_right_touch_current = event.position
+		# Continuous aim tracking
+		aim_x = event.position.x
+
+
+func _update_dpad(pos: Vector2, screen_height: float) -> void:
+	# Simple left/right based on position in left zone
+	var screen_width := get_viewport().get_visible_rect().size.x
+	var zone_center_x := screen_width * LEFT_ZONE_WIDTH * 0.5
+
+	control_left = pos.x < zone_center_x
+	control_right = pos.x >= zone_center_x
+
+
+func _has_active_touches() -> bool:
+	return _left_touch_id >= 0 or _right_touch_id >= 0
+
+
+func _draw() -> void:
+	# Draw touch control overlay (semi-transparent)
+	var screen := get_viewport().get_visible_rect().size
+	var zone_x := screen.x * LEFT_ZONE_WIDTH
+
+	# Left zone background
+	draw_rect(Rect2(0, screen.y * 0.5, zone_x, screen.y * 0.5),
+		Color(1, 1, 1, 0.05))
+
+	# D-pad buttons
+	var btn_y := screen.y - DPAD_BUTTON_SIZE - BUTTON_MARGIN
+	var left_btn := Rect2(BUTTON_MARGIN, btn_y, DPAD_BUTTON_SIZE, DPAD_BUTTON_SIZE)
+	var right_btn := Rect2(BUTTON_MARGIN + DPAD_BUTTON_SIZE + 10, btn_y,
+		DPAD_BUTTON_SIZE, DPAD_BUTTON_SIZE)
+
+	var left_color := Color(1, 1, 1, 0.3) if control_left else Color(1, 1, 1, 0.1)
+	var right_color := Color(1, 1, 1, 0.3) if control_right else Color(1, 1, 1, 0.1)
+
+	draw_rect(left_btn, left_color)
+	draw_rect(right_btn, right_color)
+
+	# Right zone - jump and aim indicator
+	var jump_btn := Rect2(screen.x - BUTTON_MARGIN - ACTION_BUTTON_SIZE,
+		btn_y - ACTION_BUTTON_SIZE - 10, ACTION_BUTTON_SIZE, ACTION_BUTTON_SIZE)
+	var crouch_btn := Rect2(screen.x - BUTTON_MARGIN - ACTION_BUTTON_SIZE,
+		btn_y, ACTION_BUTTON_SIZE, ACTION_BUTTON_SIZE)
+
+	var jump_color := Color(0.3, 1, 0.3, 0.3) if control_up else Color(0.3, 1, 0.3, 0.1)
+	var crouch_color := Color(1, 0.5, 0.3, 0.3) if control_down else Color(1, 0.5, 0.3, 0.1)
+
+	draw_rect(jump_btn, jump_color)
+	draw_rect(crouch_btn, crouch_color)
+
+	queue_redraw()

--- a/soldat-climb-mobile/scripts/verlet_physics.gd
+++ b/soldat-climb-mobile/scripts/verlet_physics.gd
@@ -1,0 +1,137 @@
+## Verlet Physics Engine - Direct port from Soldat's Parts.pas
+## Original: Copyright (c) 2001-02 Michal Marcinkowski
+##
+## This is a faithful port of Soldat's Verlet integration particle system.
+## The Verlet method stores current and previous positions instead of velocity,
+## which gives natural momentum and stable constraint satisfaction.
+
+class_name VerletPhysics
+
+const NUM_PARTICLES := 16  # Reduced from Soldat's 560 - we only need player particles
+
+var active: Array[bool] = []
+var pos: Array[Vector2] = []
+var old_pos: Array[Vector2] = []
+var velocity: Array[Vector2] = []
+var forces: Array[Vector2] = []
+var one_over_mass: Array[float] = []
+
+var time_step: float = 1.0
+var gravity: float = 0.06
+var v_damping: float = 0.99
+var e_damping: float = 0.99
+
+var constraints: Array[Dictionary] = []  # {active, part_a, part_b, rest_length}
+
+
+func _init():
+	for i in NUM_PARTICLES:
+		active.append(false)
+		pos.append(Vector2.ZERO)
+		old_pos.append(Vector2.ZERO)
+		velocity.append(Vector2.ZERO)
+		forces.append(Vector2.ZERO)
+		one_over_mass.append(1.0)
+
+
+## Core Verlet integration - direct port from Parts.pas lines 126-147
+## Formula: new_pos = (1 + damping) * pos - damping * old_pos + forces * dt^2
+func verlet(i: int) -> void:
+	# Accumulate gravity
+	forces[i].y += gravity
+
+	var temp_pos := pos[i]
+
+	# Verlet integration with velocity damping
+	# S1 = pos * (1 + VDamping), S2 = old_pos * VDamping
+	var s1 := pos[i] * (1.0 + v_damping)
+	var s2 := old_pos[i] * v_damping
+
+	var d := s1 - s2
+	var force_term := forces[i] * one_over_mass[i] * (time_step * time_step)
+
+	pos[i] = d + force_term
+	old_pos[i] = temp_pos
+
+	# Derive velocity from position change (for collision response)
+	velocity[i] = pos[i] - old_pos[i]
+
+	# Clear forces
+	forces[i] = Vector2.ZERO
+
+
+func do_verlet_timestep() -> void:
+	for i in NUM_PARTICLES:
+		if active[i]:
+			verlet(i)
+	satisfy_constraints()
+
+
+func do_verlet_timestep_for(i: int, j: int) -> void:
+	verlet(i)
+	satisfy_constraint_for(j)
+
+
+## Constraint satisfaction - maintains rigid distances between particles
+## Used for the player skeleton (gostek) bone structure
+func satisfy_constraints() -> void:
+	for c in constraints:
+		if not c.active:
+			continue
+
+		var delta := pos[c.part_b] - pos[c.part_a]
+		var delta_length := delta.length()
+		var diff := 0.0
+
+		if delta_length != 0.0:
+			diff = (delta_length - c.rest_length) / delta_length
+
+		if one_over_mass[c.part_a] > 0.0:
+			pos[c.part_a] += delta * 0.5 * diff
+
+		if one_over_mass[c.part_b] > 0.0:
+			pos[c.part_b] -= delta * 0.5 * diff
+
+
+func satisfy_constraint_for(idx: int) -> void:
+	if idx < 0 or idx >= constraints.size():
+		return
+	var c = constraints[idx]
+	var delta := pos[c.part_b] - pos[c.part_a]
+	var delta_length := delta.length()
+	var diff := 0.0
+
+	if delta_length != 0.0:
+		diff = (delta_length - c.rest_length) / delta_length
+
+	if one_over_mass[c.part_a] > 0.0:
+		pos[c.part_a] += delta * 0.5 * diff
+
+	if one_over_mass[c.part_b] > 0.0:
+		pos[c.part_b] -= delta * 0.5 * diff
+
+
+func create_part(start: Vector2, vel: Vector2, mass: float, num: int) -> void:
+	if num < 0 or num >= NUM_PARTICLES:
+		return
+	active[num] = true
+	pos[num] = start
+	velocity[num] = vel
+	old_pos[num] = start
+	one_over_mass[num] = 1.0 / mass
+
+
+func make_constraint(part_a: int, part_b: int, rest_length: float) -> void:
+	constraints.append({
+		"active": true,
+		"part_a": part_a,
+		"part_b": part_b,
+		"rest_length": rest_length,
+	})
+
+
+func stop_all_parts() -> void:
+	for i in NUM_PARTICLES:
+		if active[i]:
+			velocity[i] = Vector2.ZERO
+			old_pos[i] = pos[i]


### PR DESCRIPTION
Port of Soldat's core physics/movement system to Godot 4 GDScript for a mobile-first "Climb" game mode. Key files ported from Pascal:

- verlet_physics.gd: Verlet integration engine from Parts.pas
- movement_constants.gd: All movement tuning values from Constants.pas
- player.gd: Full movement state machine from Control.pas including direction-dependent roll/backflip mechanics, side jumps, and animation-frame-driven force application
- poly_map.gd: Polygon collision with sector spatial partitioning from PolyMap.pas
- touch_controls.gd: Mobile touch input with aim zone for facing direction and 5-frame input buffering for touch latency compensation
- climb_timer.gd: Timer, checkpoint, and death tracking
- ghost_replay.gd: Best-run ghost recording and playback
- map_data.gd: Three hand-built test maps (basic, jump course, climb tower)

Controls: Left/Right d-pad + aim zone (touch position = facing direction,
tap = jump, swipe down = crouch). Desktop: WASD + mouse aim.

https://claude.ai/code/session_01B5scD4RH81qy2pRA5FvFgr